### PR TITLE
Test pronto integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
 sudo: false
 language: ruby
 rvm:
-  - 2.5.3
+  - 2.4.1
 notifications:
   email: false
 before_install: gem install bundler -v 2.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.4.1
 notifications:
   email: false
-before_install: gem install bundler -v 2.0.1
+before_install: gem install bundler -v 2.0.1 --no-document
 cache: bundler
 script:
   - 'bundle exec pronto run -c origin/master -f text github_status github_pr_review'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.3'
+# ruby '2.5.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,8 +176,5 @@ DEPENDENCIES
   rails (~> 5.2.3)
   sqlite3
 
-RUBY VERSION
-   ruby 2.5.3p105
-
 BUNDLED WITH
    2.0.1


### PR DESCRIPTION
From Travis-CI output:
```
Pre-installed Ruby versions
ruby-2.2.7
ruby-2.3.4
ruby-2.4.1
```

So, I'm going with 2.4.1 for faster test runs.